### PR TITLE
Disable puppet service in provision template

### DIFF
--- a/hooks/post/10-setup_provisioning.rb
+++ b/hooks/post/10-setup_provisioning.rb
@@ -9,8 +9,6 @@ if app_value(:provisioning_wizard)
   # we must enforce at least one puppet run
   logger.debug 'Running puppet agent to seed foreman data'
   `service puppet stop`
-  `puppet agent -t`
-  `service puppet start`
   logger.debug 'Puppet agent run finished'
 
   logger.debug 'Installing puppet modules'


### PR DESCRIPTION
Addresses Task:  "edit provisioning template not to start puppet agent service" from: 

https://github.com/theforeman/staypuft/wiki/Puppet-ssh
