### PR TITLE
Fix output during interupt or cancel

### DIFF
--- a/bin/staypuft-installer
+++ b/bin/staypuft-installer
@@ -74,6 +74,9 @@ if [0,2].include? @result.exit_code
     say "  * <%= color('Puppetmaster', :info) %> is running at <%= color('port #{get_param('puppet','server_port')}', :info) %>"
   end
   exit_code = 0
+elsif @result.exit_code == 100
+  # user cancelled installation
+  exit_code = 0
 else
   say "  <%= color('Something went wrong!', :bad) %> Check the log for ERROR-level output"
   exit_code = @result.exit_code

--- a/hooks/lib/provisioning_wizard.rb
+++ b/hooks/lib/provisioning_wizard.rb
@@ -16,6 +16,7 @@ class ProvisioningWizard
   attr_accessor *NIC_ATTRS.keys
 
   def initialize(kafo)
+    @kafo   = kafo
     @logger = kafo.logger
     # set default value according to parameter value
     NIC_ATTRS.each_pair do |attr, name|
@@ -110,11 +111,11 @@ class ProvisioningWizard
         name = NIC_ATTRS[attr.to_sym]
         menu.choice("No, change #{name}") { attr.to_sym }
       end
-      menu.choice(HighLine.color('No, cancel installation', :cancel)) { exit 0 }
+      menu.choice(HighLine.color('No, cancel installation', :cancel)) { @kafo.class.exit(100) }
     end
   rescue Interrupt
     @logger.debug "Got interrupt, exiting"
-    exit(0)
+    @kafo.class.exit(100)
   end
 
   def get_nic


### PR DESCRIPTION
This uses kafo 0.6 new exit handler so we don't print success messages when user interupts wizard or cancels installation.
