### PR TITLE
Nodaemon puppetssh

### DIFF
--- a/config/staypuft-installer.answers.yaml
+++ b/config/staypuft-installer.answers.yaml
@@ -17,6 +17,7 @@ foreman_proxy:
   custom_repo: true
   puppetrun_provider: 'puppetssh'
   puppetssh_keyfile: "/usr/share/foreman-proxy/.ssh/id_rsa"
+  puppetssh_command: "/usr/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize"
 sshkeypair:
   home: '/etc/foreman-proxy/'
   user: 'foreman-proxy'


### PR DESCRIPTION
Service puppet stop kills any running puppet agent daemon.  This is causing any --onetime puppetssh runs to fail mid run when trying to stop the agent service.  Running in non daemon modes prevents this.
