### PR TITLE
Fix BZ#1103151

### DIFF
--- a/hooks/lib/subscription_seeder.rb
+++ b/hooks/lib/subscription_seeder.rb
@@ -23,10 +23,20 @@ class SubscriptionSeeder < BaseSeeder
     @repo_path = @config.get_custom(:repo_path) || 'http://'
     @sm_pool = @config.get_custom(:sm_pool) ||''
     @skip = false
+    @skip_repo_path = false
   end
 
   def seed
     if subscription_seed?
+      say "\nNow you should configure installation media which will be used for provisioning."
+      say "Note that if you don't configure it properly, host provisioning won't work until you configure installation media manually."
+      get = get_repo_path
+      while get || (invalid_repo_path && !@skip_repo_path)
+        puts HighLine.color(invalid_repo_path, :bad) if !get && invalid_repo_path
+        get = get_repo_path
+      end
+      @config.set_custom(:repo_path, @repo_path)
+
       get = get_credentials
       while get || (invalid && !@skip)
         puts HighLine.color(invalid, :bad) if !get && invalid
@@ -36,17 +46,19 @@ class SubscriptionSeeder < BaseSeeder
       @config.set_custom(:sm_username, @sm_username)
       @config.set_custom(:sm_password, @sm_password)
       @config.set_custom(:repositories, @repositories)
-      @config.set_custom(:repo_path, @repo_path)
       @config.set_custom(:sm_pool, @sm_pool)
       @config.save_configuration(@config.app)
     else
       @skip = true
+      @skip_repo_path = true
     end
 
-    @foreman.medium.show_or_ensure({'id' => 'RedHat mirror'},
-                                                {'name' => 'RedHat mirror',
-                                                 'path' => @repo_path,
-                                                 'os_family' => 'Redhat'})
+    unless @skip_repo_path
+      @foreman.medium.show_or_ensure({'id' => 'RedHat mirror'},
+                                     {'name' => 'RedHat mirror',
+                                      'path' => @repo_path,
+                                      'os_family' => 'Redhat'})
+    end
 
     unless @skip
       @oses.each do |os|
@@ -87,33 +99,59 @@ class SubscriptionSeeder < BaseSeeder
 
   private
 
+  def invalid_repo_path
+    message = "\n"
+    message += "Repository path can't be empty\n" if @repo_path.empty?
+    message += "Repository path is not valid\n" if repo_path_invalid?
+    message += "Repository path protocol is not supported, use http or https\n" unless repo_path_supported_scheme?
+    message == "\n" ? false : message
+  end
+
   def invalid
     message = "\n"
     message += "Subscription manager username can't be empty\n" if @sm_username.empty?
     message += "Subscription manager password can't be empty\n" if @sm_password.empty?
-    message += "Repository path can't be empty\n" if @repo_path.empty?
-    message += "Repository path is not valid\n" if repo_path_invalid?
     message == "\n" ? false : message
   end
 
   def repo_path_invalid?
-    URI.parse(@repo_path)
+    @parsed_uri = URI.parse(@repo_path)
     return false
   rescue URI::InvalidURIError => e
     @logger.debug "User tried to use invalid repo path: #{e.message}"
     return true
   end
 
-  def get_credentials
+  def repo_path_supported_scheme?
+    if @parsed_uri
+      return %w(http https).include?(@parsed_uri.scheme)
+    else
+      return true # don't print error for this check, it was catched sooner
+    end
+  end
+
+  def get_repo_path
     choose do |menu|
-      menu.header = HighLine.color("\nEnter your subscription manager credentials?", :important)
+      menu.header = HighLine.color("\nEnter RHEL repo path", :important)
       menu.select_by = :index
       menu.prompt = ''
-      menu.choice('Subscription manager username: '.ljust(37) + HighLine.color(@sm_username, :info)) { @sm_username = ask("Username: ")  }
+      menu.choice('Set RHEL repo path (http or https URL): '.ljust(37) + HighLine.color(@repo_path, :info)) { @repo_path = ask("Path: ") }
+      menu.choice(HighLine.color('Proceed with configuration', :run)) { false }
+      menu.choice(HighLine.color("Skip this step (provisioning won't work)", :cancel)) {
+        @skip_repo_path = true; false
+      }
+    end
+  end
+
+  def get_credentials
+    choose do |menu|
+      menu.header = HighLine.color("\nEnter your subscription manager credentials", :important)
+      menu.select_by = :index
+      menu.prompt = ''
+      menu.choice('Subscription manager username: '.ljust(37) + HighLine.color(@sm_username, :info)) { @sm_username = ask("Username: ") }
       menu.choice('Subscription manager password: '.ljust(37) + HighLine.color('*' * @sm_password.size, :info)) { @sm_password = ask("Password: ") { |q| q.echo = "*" } }
-      menu.choice('Comma separated repositories: '.ljust(37) + HighLine.color(@repositories, :info)) { print 'value: '; @repositories = ask("Repositories: ") }
-      menu.choice('RHEL repo path (http or https URL): '.ljust(37) + HighLine.color(@repo_path, :info)) { print 'value: '; @repo_path = ask("Path: ") }
-      menu.choice('Subscription manager pool (optional): '.ljust(37) + HighLine.color(@sm_pool, :info)) { print 'value: '; @sm_pool = ask("Pool: ") }
+      menu.choice('Comma separated repositories: '.ljust(37) + HighLine.color(@repositories, :info)) { @repositories = ask("Repositories: ") }
+      menu.choice('Subscription manager pool (optional): '.ljust(37) + HighLine.color(@sm_pool, :info)) { @sm_pool = ask("Pool: ") }
       menu.choice(HighLine.color('Proceed with configuration', :run)) { false }
       menu.choice(HighLine.color("Skip this step (provisioning won't subscribe your machines)", :cancel)) {
         @skip = true; false


### PR DESCRIPTION
There's a new small wizard to ask for repo path that runs validations.
It can be optionally skipped but user is warned that provisiong wouldn't
work.
