### PR TITLE
Support random generated password

### DIFF
--- a/hooks/lib/base_seeder.rb
+++ b/hooks/lib/base_seeder.rb
@@ -4,8 +4,10 @@ require 'uri'
 class BaseSeeder
   def initialize(kafo)
     @foreman_url = kafo.param('foreman_proxy', 'foreman_base_url').value
-    @username = 'admin'
-    @password = 'changeme'
+    param = kafo.param('foreman', 'admin_username')
+    @username = param.nil? ? 'admin' : param.value
+    param = kafo.param('foreman', 'admin_password')
+    @password = param.nil? ? 'changeme' : param.value
     foreman
 
     @logger = kafo.logger


### PR DESCRIPTION
Foreman 1.6 adds new installer parameters and generates random password
by default. We try to find these parameters values and fallback to
default ones so it's back compatible with 1.5
