### PR TITLE
don't require 100GB for root filesystem

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -561,8 +561,8 @@ zerombr
 clearpart --all --initlabel
 part /boot --fstype ext3 --size=500 --ondisk=sda
 part swap --size=1024 --ondisk=sda
-part pv.01 --size=102400 --ondisk=sda
-part pv.02 --size=1 --grow --ondisk=sda
+part pv.01 --size=1024 --grow --maxsize=102400 --ondisk=sda
+part pv.02 --size=1024 --grow --ondisk=sda
 volgroup vg_root pv.01
 volgroup cinder-volumes pv.02
 logvol  /  --vgname=vg_root  --size=1 --grow --name=lv_root


### PR DESCRIPTION
This changes the "LVM with cinder-volumes" layout such that we no longer
require 100GB for the root lv (via requiring 100GB for pv.01).  With
this change, we default both pv.01 and pv.02 to 1GB, and allow pv.01 to
grow up to 100GB and pv.02 to grow as large as possible.

Resolves: rhbz#1122753
