### PR TITLE
Bz/1124027

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -327,12 +327,14 @@ exec < /dev/tty3 > /dev/tty3
 # (resolves https://bugzilla.redhat.com/show_bug.cgi?id=1124027)
 
 # get name of provisioning interface
-PROVISION_IFACE=$(ip route  | awk '$1 == "default" {print $5}')
+PROVISION_IFACE=$(ip route  | awk '$1 == "default" {print $5}' | head -1)
+echo "found provisioning interface = $PROVISION_IFACE"
 
 IFACES=$(ls -d /sys/class/net/* | while read iface; do readlink $iface | grep -q virtual || echo ${iface##*/}; done)
 for i in $IFACES; do
     sed -i 's/ONBOOT.*/ONBOOT=yes/' /etc/sysconfig/network-scripts/ifcfg-$i
     if [ "$i" != "$PROVISION_IFACE" ]; then
+        echo "setting PEERDNS=no on $i"
         sed -i '
             /PEERDNS/ d
             $ a\PEERDNS=no


### PR DESCRIPTION
set PEERDNS=no on all but provision interface

This ensures that we don't override foreman-configured resolv.conf with information from another dhcp server.
