### PR TITLE
BZ#1125075 - Do not install firewalld during kickstart

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -345,6 +345,9 @@ echo "updating system time"
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
 
+# ensure firewalld is absent (BZ#1125075)
+yum -t -y -e 0 remove firewalld
+
 <% if puppet_enabled %>
 # and add the puppet package
 yum -t -y -e 0 install puppet
@@ -500,6 +503,9 @@ echo "updating system time"
 
 # update all the base packages from the updates repository
 yum -t -y -e 0 update
+
+# ensure firewalld is absent (BZ#1125075)
+yum -t -y -e 0 remove firewalld
 
 <% if puppet_enabled %>
 echo "Configuring puppet"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1125075

This avoids conflicts between firewalld and iptables-services.
