### PR TITLE
BZ#1127196 - ask for password confirmation

### DIFF
--- a/hooks/lib/authentication_wizard.rb
+++ b/hooks/lib/authentication_wizard.rb
@@ -28,7 +28,9 @@ class AuthenticationWizard < BaseWizard
   attr_accessor *attrs.keys
 
   def get_root_password
+    @root_password_set_interactively = true
     @root_password = ask("new value for root password") { |q| q.echo = '*' }
+    @root_password_confirmation = ask("enter new root password again to confirm") { |q| q.echo = '*' }
   end
 
   def get_ssh_public_key
@@ -50,6 +52,12 @@ class AuthenticationWizard < BaseWizard
 
   def validate_root_password
     return "Password must be at least 8 characters long" if @root_password.nil? || @root_password.length < 8
+
+    # confirmation validation should not be done if running non-interactively,
+    # or interactively but with password loaded from answer file
+    if @root_password_set_interactively && @root_password != @root_password_confirmation
+      return "Password and confirmation do not match, please re-enter the password"
+    end
   end
 
   def print_pair(name, value)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1127196

Installer now asks for password confirmation when setting root
password for newly provisioned machines. Password validation will fail
if the confirmation does not match the password.
