### PR TITLE
disable biosdevname for discovery image

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -610,7 +610,7 @@ ONTIMEOUT discovery
 LABEL discovery
 MENU LABEL Foreman Discovery
 KERNEL boot/#{@kernel}
-APPEND rootflags=loop initrd=boot/#{@initrd} root=live:/foreman.iso rootfstype=auto ro rd.live.image rd.live.check rd.lvm=0 rootflags=ro crashkernel=128M elevator=deadline max_loop=256 rd.luks=0 rd.md=0 rd.dm=0 foreman.url=#{@foreman_url} nomodeset selinux=0 stateless
+APPEND rootflags=loop initrd=boot/#{@initrd} root=live:/foreman.iso rootfstype=auto ro rd.live.image rd.live.check rd.lvm=0 rootflags=ro crashkernel=128M elevator=deadline max_loop=256 rd.luks=0 rd.md=0 rd.dm=0 foreman.url=#{@foreman_url} nomodeset selinux=0 stateless biosdevname=0
 IPAPPEND 2
 EOS
   end


### PR DESCRIPTION
we disable biosdevname for general OS booting but left it on for
discovery.  This disables it for discovery so net.ifnames is used.

Signed-off-by: Mike Burns mburns@redhat.com
