### PR TITLE
BZ#1142182 - provisioned hosts have wrong timezone

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -20,6 +20,7 @@ class ProvisioningSeeder < BaseSeeder
     @default_root_pass = kafo.param('foreman_plugin_staypuft', 'root_password').instance_variable_get('@value')
     @default_ssh_public_key = kafo.param('foreman_plugin_staypuft', 'ssh_public_key').value
     @ntp_host = kafo.param('foreman_plugin_staypuft', 'ntp_host').value
+    @timezone = kafo.param('foreman_plugin_staypuft', 'timezone').value
   end
 
   def seed
@@ -128,6 +129,11 @@ class ProvisioningSeeder < BaseSeeder
                                         {
                                             'name' => 'ntp-server',
                                             'value' => @ntp_host,
+                                        })
+      @foreman.parameter.show_or_ensure({'id' => 'time-zone', 'operatingsystem_id' => os['id']},
+                                        {
+                                            'name' => 'time-zone',
+                                            'value' => @timezone,
                                         })
       @hostgroups.push hostgroup
     end

--- a/hooks/pre_validations/10-gather_and_set_staypuft_values.rb
+++ b/hooks/pre_validations/10-gather_and_set_staypuft_values.rb
@@ -57,6 +57,7 @@ if app_value(:provisioning_wizard) != 'none'
   param('foreman_plugin_staypuft', 'domain').value = provisioning_wizard.domain
   param('foreman_plugin_staypuft', 'base_url').value = provisioning_wizard.base_url
   param('foreman_plugin_staypuft', 'ntp_host').value = provisioning_wizard.ntp_host
+  param('foreman_plugin_staypuft', 'timezone').value = provisioning_wizard.timezone
   param('foreman_plugin_staypuft', 'root_password').value = authentication_wizard.root_password
   param('foreman_plugin_staypuft', 'ssh_public_key').value = authentication_wizard.ssh_public_key
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1142182

This adds support for setting timezone. The timezone will be set both
on the Foreman host and on the provisioned hosts. The timezone
defaults to the timezone currently set on the host where
staypuft-installer is run. The implementation should be forward
compatible for when Staypuft will run on EL 7 variants.

How i tested:

Set timezone to "Pacific/Auckland". On Staypuft host after running the installer:

```
[root@r6-staypuft ~]# cat /etc/sysconfig/clock
ZONE="Pacific/Auckland"
[root@r6-staypuft ~]# date
So zář 20 03:10:42 NZST 2014
```

On provisioned host:

```
[root@r7-sp1 ~]# timedatectl 
      Local time: So 2014-09-20 03:11:57 NZST
  Universal time: Pá 2014-09-19 15:11:57 UTC
        RTC time: Pá 2014-09-19 15:11:57
        Timezone: Pacific/Auckland (NZST, +1200)
     NTP enabled: no
NTP synchronized: no
 RTC in local TZ: no
      DST active: no
 Last DST change: DST ended at
                  Ne 2014-04-06 02:59:59 NZDT
                  Ne 2014-04-06 02:00:00 NZST
 Next DST change: DST begins (the clock jumps one hour forward) at
                  Ne 2014-09-28 01:59:59 NZST
                  Ne 2014-09-28 03:00:00 NZDT
```
