### PR TITLE
Remove 'service network restart' from network config snippet

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -715,7 +715,6 @@ for i in $IFACES; do
     fi 
 done
 
-service network restart
 EOS
   end
 


### PR DESCRIPTION
Restarting the network during a kickstart can have ill effects,
including the primary interface not coming back up. The snippet should
just configure the networking, and leave the install environment alone.
The networking config will take effect upon reboot.
