### PR TITLE
rhbz#1148189 don't restart network in kickstart

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -714,8 +714,6 @@ for i in $IFACES; do
         ' /etc/sysconfig/network-scripts/ifcfg-$i
     fi 
 done
-
-service network restart
 EOS
   end
 


### PR DESCRIPTION
the network is configured during pxe, but should not be restarted

Signed-off-by: Mike Burns mburns@redhat.com
