### PR TITLE
BZ#1147577: Add biosboot partition in case GPT disk label

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -723,6 +723,7 @@ EOS
 #Dynamic
 zerombr
 clearpart --all --initlabel
+part biosboot --fstype=biosboot --size=1 --ondisk=sda
 part /boot --fstype ext3 --size=500 --ondisk=sda
 part swap --size=1024 --ondisk=sda
 part pv.01 --size=1024 --grow --maxsize=102400 --ondisk=sda
@@ -738,6 +739,7 @@ EOS
 #Dynamic
 zerombr
 clearpart --all --initlabel
+part biosboot --fstype=biosboot --size=1 --ondisk=sda
 part /boot --fstype ext3 --size=500 --ondisk=sda
 part swap --size=1024 --ondisk=sda
 part pv.01 --size=1024 --grow --ondisk=sda


### PR DESCRIPTION
When a GPT disk label is used, particularly disks > 2TB, the biosboot
partition is required to boot.
