### PR TITLE
Add staypuft-register-host command

### DIFF
--- a/bin/staypuft-register-host
+++ b/bin/staypuft-register-host
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+set -e
+
+# uncomment for developer mode :)
+# set -uo pipefail
+
+PUPPET_CONF_TEMPLATE="
+[main]
+    # The Puppet log directory.
+    # The default value is '\$vardir/log'.
+    logdir = /var/log/puppet
+
+    # Where Puppet PID files are kept.
+    # The default value is '\$vardir/run'.
+    rundir = /var/run/puppet
+
+    # Where SSL certificates are kept.
+    # The default value is '\$confdir/ssl'.
+    ssldir = \$vardir/ssl
+
+    # Allow services in the 'puppet' group to access key (Foreman + proxy)
+    privatekeydir = \$ssldir/private_keys { group = service }
+    hostprivkey = \$privatekeydir/\$certname.pem { mode = 640 }
+
+    # Puppet 3.0.x requires this in both [main] and [master] - harmless on agents
+    autosign       = \$confdir/autosign.conf { mode = 664 }
+
+    show_diff     = false
+
+    hiera_config = \$confdir/hiera.yaml
+
+[agent]
+    # The file in which puppetd stores a list of the classes
+    # associated with the retrieved configuration.  Can be loaded in
+    # the separate ``puppet`` executable using the ``--loadclasses``
+    # option.
+    # The default value is '\$statedir/classes.txt'.
+    classfile = \$vardir/classes.txt
+
+    # Where puppetd caches the local configuration.  An
+    # extension indicating the cache format is added automatically.
+    # The default value is '\$confdir/localconfig'.
+    localconfig = \$vardir/localconfig
+
+    # Disable the default schedules as they cause continual skipped
+    # resources to be displayed in Foreman - only for Puppet >= 3.4
+    default_schedules = false
+
+    report            = true
+    pluginsync        = true
+    masterport        = 8140
+    environment       = production
+    certname          = CERTNAME_PLACEHOLDER
+    server            = PUPPETMASTER_PLACEHOLDER
+    listen            = false
+    splay             = false
+    splaylimit        = 1800
+    runinterval       = 1800
+    noop              = false
+    configtimeout     = 120
+    usecacheonfailure = true
+"
+
+function main() {
+    DEBUG=''
+
+    while true ; do
+        case "${1:-}" in
+            -h | --help) print_usage_and_exit 0 ;;
+            -d | --debug) set -x; DEBUG=true; shift ;;
+            --) shift; break ;;
+            -*) echo "Unsupported option ${1:-}"; print_usage_and_exit ;;
+            *) break ;;
+        esac
+    done
+
+    if [ $# != 1 ]; then
+        print_usage_and_exit
+    fi
+
+    HOST_FQDN=$1
+    CERTNAME=$HOST_FQDN
+    ENABLE_REPOS=${ENABLE_REPOS-}
+    PUPPETMASTER=${PUPPETMASTER:-$(hostname -f)}
+    SSH_OPTIONS=${SSH_OPTIONS:-}
+
+    if [ ! -z "$ENABLE_REPOS" ]; then
+        MULTIPLE_REPOS_ARGS=$(echo "$ENABLE_REPOS" | sed -e 's/,/ --enable=/g')
+        echo "Enabling repositories..."
+        ssh $SSH_OPTIONS "root@$HOST_FQDN" "subscription-manager repos --enable=$MULTIPLE_REPOS_ARGS"
+    fi
+
+    echo "Installing Puppet..."
+    ssh "root@$HOST_FQDN" "yum -y install puppet"
+
+    echo "Uploading puppet.conf..."
+    ssh "root@$HOST_FQDN" "mkdir -p /etc/puppet"
+    echo "$PUPPET_CONF_TEMPLATE" \
+        | sed -e "s/CERTNAME_PLACEHOLDER/$CERTNAME/" \
+        | sed -e "s/PUPPETMASTER_PLACEHOLDER/$PUPPETMASTER/" \
+        | ssh $SSH_OPTIONS "root@$HOST_FQDN" "cat > /etc/puppet/puppet.conf"
+
+    echo "Registering with installer host and waiting for certificate..."
+    PUPPET_OUTPUT_FILTER=" | grep --line-buffered -v -i -E '^(Warning: )|(Notice: /File)'"
+    if [ "$DEBUG" = 'true' ]; then
+        PUPPET_OUTPUT_FILTER=''
+    fi
+    ssh $SSH_OPTIONS "root@$HOST_FQDN" "puppet agent -v --color false --onetime --no-daemonize --waitforcert 15 --tags no_such_tag 2>&1 $PUPPET_OUTPUT_FILTER"
+
+    echo "Enabling and starting the Puppet service..."
+    ssh $SSH_OPTIONS "root@$HOST_FQDN" "systemctl enable puppet.service && systemctl start puppet.service"
+
+    echo "Done."
+}
+
+function print_usage_and_exit() {
+    echo "
+Usage: $(basename "$0") [options] <host_fqdn>
+
+Registers non-provisioned hosts to the installer.
+
+
+Environment variables:
+
+PUPPETMASTER - puppetmaster to be written to puppet.conf (should be the
+               installer host), defaults to FQDN of the host where this
+               script runs
+ENABLE_REPOS - comma separated list of repositories to enable on the
+               target host using subscription-manager
+SSH_OPTIONS  - extra options for ssh invocations used within the script
+
+Positional arguments:
+
+host_fqdn    - FQDN (not IP address) of the host to register
+
+Options:
+
+-h, --help   - this usage info and exit
+-d, --debug  - debugging mode
+"
+
+    exit ${1-1}
+}
+
+main "$@"

--- a/foreman-installer-staypuft.spec
+++ b/foreman-installer-staypuft.spec
@@ -49,6 +49,8 @@ install -d -m0755 %{buildroot}%{_datadir}/foreman-installer
 cp -R hooks modules %{buildroot}%{_datadir}/foreman-installer
 install -d -m0755 %{buildroot}%{_sbindir}
 cp bin/staypuft-installer %{buildroot}%{_sbindir}/staypuft-installer
+install -d -m0755 %{buildroot}%{_bindir}
+cp bin/staypuft-register-host %{buildroot}%{_bindir}/staypuft-register-host
 install -d -m0755 %{buildroot}%{_sysconfdir}/foreman/
 cp config/staypuft-installer.yaml %{buildroot}%{_sysconfdir}/foreman/staypuft-installer.yaml
 cp config/staypuft-installer.answers.yaml %{buildroot}%{_sysconfdir}/foreman/staypuft-installer.answers.yaml
@@ -77,6 +79,7 @@ cp config/staypuft-installer.answers.yaml %{buildroot}%{_sysconfdir}/foreman/sta
 %config %attr(600, root, root) %{_sysconfdir}/foreman/staypuft-installer.yaml
 %config(noreplace) %attr(600, root, root) %{_sysconfdir}/foreman/staypuft-installer.answers.yaml
 %{_sbindir}/staypuft-installer
+%{_bindir}/staypuft-register-host
 
 %changelog
 * Tue Sep 23 2014 Marek Hulan <mhulan@redhat.com> 0.4.1-1


### PR DESCRIPTION
Simplifies registration of non-provisioned hosts into Staypuft.
