### PR TITLE
Correct the config when a bond and vlan are used together

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -676,11 +676,13 @@ EOF
 <% bonded_interfaces = [] %>
 <% bonds = @host.bond_interfaces %>
 <% bonds.each do |bond| %>
+<% subnet = bond.subnet -%>
+<% dhcp = subnet.nil? ? false : subnet.dhcp_boot_mode? -%>
 # <%= bond.identifier %> interface
 real="<%= bond.identifier -%>"
 cat << EOF > /etc/sysconfig/network-scripts/ifcfg-$real
 BOOTPROTO="<%= dhcp ? 'dhcp' : 'none' -%>"
-<% unless dhcp -%>
+<% unless dhcp || subnet.nil? -%>
 IPADDR="<%= bond.ip -%>"
 NETMASK="<%= subnet.mask -%>"
 GATEWAY="<%= subnet.gateway -%>"


### PR DESCRIPTION
When a bond and a vlan are used together, and the subnet assigned to
the vlan is not set to dhcp mode, there is no IP info for the
bond interface itself. It is gathered and attached on the vlan
interface. This checks that the bond is actually assigned to a subnet
before trying to write out static IP information.
