### PR TITLE
BZ #1162794: Properly configure bond interfaces with vlans

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -748,9 +748,10 @@ EOF
 <% dhcp = subnet.nil? ? false : subnet.dhcp_boot_mode? -%>
 
 # <%= interface.identifier %> interface
+<% unless virtual -%>
 real=`ip -o link | grep <%= interface.mac -%> | awk '{print $2;}' | sed s/:$//`
-<% if virtual -%>
-real=`echo <%= interface.identifier -%> | sed s/<%= interface.attached_to -%>/$real/`
+<% else -%>
+real="<%= interface.identifier -%>"
 <% end -%>
 
 cat << EOF > /etc/sysconfig/network-scripts/ifcfg-$real


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1162794

If no MAC address was associated with a VLAN's parent interface (as is
the case of bonds), the interface would not be properly set up.
