### PR TITLE
the installer repo is required for client installation

### DIFF
--- a/hooks/lib/subscription_seeder.rb
+++ b/hooks/lib/subscription_seeder.rb
@@ -19,7 +19,7 @@ class SubscriptionSeeder < BaseSeeder
 
     @sm_username = @config.get_custom(:sm_username) || ''
     @sm_password = @config.get_custom(:sm_password) || ''
-    @repositories = @config.get_custom(:repositories) || 'rhel-7-server-openstack-6.0-rpms'
+    @repositories = @config.get_custom(:repositories) || 'rhel-7-server-openstack-6.0-rpms rhel-7-server-openstack-6.0-installer-rpms'
     @sm_proxy_user = @config.get_custom(:sm_proxy_user) || ''
     @sm_proxy_password = @config.get_custom(:sm_proxy_password) || ''
     @sm_proxy_host = @config.get_custom(:sm_proxy_host) || ''


### PR DESCRIPTION
the client rpm needs to be installed on client machines so we need
the installer repo available on client machines by default.
