### PR TITLE
BZ#1167880 puppet error "Could not find class quickstack::openstack_comm...

### DIFF
--- a/hooks/lib/install_modules.sh
+++ b/hooks/lib/install_modules.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
-TARGET=/etc/puppet/environments/production/modules/
+TARGET=/etc/puppet/environments/production/modules
 OFI_MODULES=/usr/share/openstack-foreman-installer/puppet/modules
 OS_MODULES=/usr/share/openstack-puppet/modules
 INSTALLER_MODULES=/usr/share/foreman-installer/modules
 
 if [ -d $OFI_MODULES -a -d $OS_MODULES ]; then
   # copy modules from packages
-  for mod in "$OFI_MODULES/*"; do
-    ln -nfs $mod $TARGET
-  done
-
-  for mod in "$OS_MODULES/*"; do
-    ln -nfs $mod $TARGET
+  ofi_mods="$OFI_MODULES/*"
+  os_mods="$OS_MODULES/*"
+  all_mods=( "${ofi_mods[@]}" "${os_mods[@]}" )
+  for mod_path in ${all_mods[@]}; do
+      mod_name=$(basename "$mod_path")
+      # rm to make sure the modules are identical (no files left over)
+      rm -rf "$TARGET/$mod_name"
+      echo "$mod_path to $TARGET/$mod_name"
+      cp -r "$mod_path" "$TARGET/"
   done
 else
   # get stable modules for git repositories
@@ -39,12 +42,12 @@ else
   mv openstack-puppet-modules/* modules
   rm -rf astapor openstack-puppet-modules
 
-  mv modules/* $TARGET
+  mv modules/* $TARGET/
 fi
 
 # make a copy of installer modules (installer update should not change anything in master)
 mod_name="foreman"
 mod="$INSTALLER_MODULES/$mod_name"
 if [ ! -d $TARGET/$mod_name ]; then
-  cp -r $mod $TARGET
+  cp -r $mod $TARGET/
 fi


### PR DESCRIPTION
The SELinux policy doesn't allow symlinks in /etc/puppet. We need to
copy over the OpenStack modules instead of linking to them.
