### PR TITLE
BZ #1148947: Make kickstart template consistent with disk layout

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -531,11 +531,7 @@ part biosboot --fstype=biosboot --size=1
 bootloader --location=mbr --append="nofb quiet splash=quiet" <%= grub_pass %>
 <% end -%>
 
-<% if @dynamic -%>
 %include /tmp/diskpart.cfg
-<% else -%>
-<%= @host.diskLayout %>
-<% end -%>
 
 text
 reboot
@@ -555,11 +551,15 @@ puppetlabs-release
 <% end -%>
 %end
 
-<% if @dynamic -%>
+
 %pre
+cat > /tmp/diskpart.cfg << EOF
 <%= @host.diskLayout %>
+EOF
+# ensures a valid disk is addressed in the partition table layout
+# sda is assumed and replaced if it is not correct
+sed -i "s/sda/$(cat /proc/partitions | awk '{ print $4 }' | grep -e "^.d.$" | sort | head -1)/" /tmp/diskpart.cfg
 %end
-<% end -%>
 
 %post --nochroot
 exec < /dev/tty3 > /dev/tty3


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1148947

The disk layout portions of the kickstart template were inconsistent,
causing errors on other distros (CentOS). This should fix that.
