### PR TITLE
BZ#1173634 - deployment runs without completing/failing

### DIFF
--- a/config/staypuft-installer.answers.yaml
+++ b/config/staypuft-installer.answers.yaml
@@ -17,7 +17,7 @@ foreman_proxy:
   custom_repo: true
   puppetrun_provider: 'puppetssh'
   puppetssh_keyfile: "/usr/share/foreman-proxy/.ssh/id_rsa"
-  puppetssh_command: "/usr/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize"
+  puppetssh_command: "/usr/bin/sleep 30; /usr/bin/pkill puppet; /usr/bin/sleep 5; /usr/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize"
 sshkeypair:
   home: '/etc/foreman-proxy/'
   user: 'foreman-proxy'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1173634

There seems to be a race condition between previous puppet runs still
finishing, and new ones starting:

Dec 11 17:55:43 maca25400702876 puppet-agent[4013]: Finished catalog run in 1939.18 seconds
Dec 11 17:56:12 maca25400702876 puppet-agent[22063]: Run of Puppet configuration client already in progress; skipping

Which means that the latter puppet run never runs and never sends a
report to foreman, and the deployment is stuck on the ReportWait
action forever.

This change should make the puppetssh-triggered runs more resilient -
they'll give the previous run a bit more time to finish, and then kill
puppet if necessary.
