### PR TITLE
BZ #1173634 - deployment runs without completing/failing

### DIFF
--- a/config/staypuft-installer.answers.yaml
+++ b/config/staypuft-installer.answers.yaml
@@ -17,7 +17,7 @@ foreman_proxy:
   custom_repo: true
   puppetrun_provider: 'puppetssh'
   puppetssh_keyfile: "/usr/share/foreman-proxy/.ssh/id_rsa"
-  puppetssh_command: "/usr/bin/sleep 30; /usr/bin/pkill puppet; /usr/bin/sleep 5; /usr/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize"
+  puppetssh_command: "/usr/bin/sleep 30; /usr/bin/pkill puppet; /usr/bin/sleep 10; /usr/bin/rm -f /var/lib/puppet/state/agent_catalog_run.lock; /usr/bin/puppet agent --onetime --no-usecacheonfailure --no-daemonize"
 sshkeypair:
   home: '/etc/foreman-proxy/'
   user: 'foreman-proxy'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1173634

In case puppet gets killed by puppetssh, we should also ensure that
the puppet agent lockfile is removed. Also Puppet now has 5 more
seconds to exit and clean up the lockfile by itself.