### PR TITLE
BZ #1180322: Install mariadb on controllers before puppet

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -427,6 +427,11 @@ yum -t -y -e 0 update
 # ensure firewalld is absent (BZ#1125075)
 yum -t -y -e 0 remove firewalld
 
+# Ensure mariadb is installed on controllers before puppet run
+<% if @host.hostgroup.to_s.include?("Controller") -%>
+yum -t -y -e 0 install mariadb
+<% end -%>
+
 <% if puppet_enabled %>
 # and add the puppet package
 yum -t -y -e 0 install puppet
@@ -609,6 +614,11 @@ yum -t -y -e 0 update
 
 # ensure firewalld is absent (BZ#1125075)
 yum -t -y -e 0 remove firewalld
+
+# Ensure mariadb is installed on controllers before puppet run
+<% if @host.hostgroup.to_s.include?("Controller") -%>
+yum -t -y -e 0 install mariadb
+<% end -%>
 
 <% if puppet_enabled %>
 echo "Configuring puppet"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1180322

Install mariadb on controllers before puppet is installed.