### PR TITLE
BZ#1180322 - errors on registration puppet run

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -654,6 +654,9 @@ yum install -t -e 0 -y foreman-installer-staypuft-client
 cat > /etc/foreman/staypuft-client-installer.answers.yaml << EOF
 <%= snippet 'staypuft-client-installer-answers-yaml' %>
 EOF
+# Run the installer twice to mitigate potential pluginsync timeouts
+# https://github.com/theforeman/staypuft/pull/414#issuecomment-71828263
+staypuft-client-installer
 staypuft-client-installer
 EOS
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1180322

The main part of this issue is solved in Staypuft [1], but the first
puppet run could still fail due to pluginsync taking too long. The
pluginsync timeout is not configurable and is supposed to happen fast.
But we have a lot of modules and in virtualized testing environments the
puppetmaster machine serving the plugins and 4 or 5 clients fetching the
plugins are in fact served by the same hardware (usually just one HDD),
so this can take longer time and exceed the timeout. Only reasonable fix
seems to be just to run the installer twice to let the pluginsync
finish.

If the first pluginsync times out, the first report for that host will
contain errors, but the second run should finish the plugin sync and
therefore the host would be marked with "error" in Foreman for a very
short time, not for large part of OpenStack deployment duration, as it
was previously.

[1] https://github.com/theforeman/staypuft/pull/414