### PR TITLE
BZ#1188704 -  overloaded machine hits timeout in node.rb

### DIFF
--- a/config/staypuft-installer.answers.yaml
+++ b/config/staypuft-installer.answers.yaml
@@ -24,6 +24,7 @@ sshkeypair:
   group: 'foreman-proxy'
 puppet:
   server: true
+  server_noderb_timeout: 60
 "foreman::plugin::discovery":
   install_images: false
 "foreman::plugin::tasks": true


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1188704

Changes the default node.rb timeout from 10 to 60 seconds.