### PR TITLE
BZ #1191732: Add ntp-servers to OS parameters

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -162,6 +162,11 @@ class ProvisioningSeeder < BaseSeeder
       @foreman.parameter.show_or_ensure({'id' => 'ntp-server', 'operatingsystem_id' => os['id']},
                                         {
                                             'name' => 'ntp-server',
+                                            'value' => @ntp_host.split(',').first,
+                                        })
+      @foreman.parameter.show_or_ensure({'id' => 'ntp-servers', 'operatingsystem_id' => os['id']},
+                                        {
+                                            'name' => 'ntp-servers',
                                             'value' => @ntp_host,
                                         })
       @foreman.parameter.show_or_ensure({'id' => 'time-zone', 'operatingsystem_id' => os['id']},

--- a/hooks/lib/provisioning_wizard.rb
+++ b/hooks/lib/provisioning_wizard.rb
@@ -57,6 +57,10 @@ class ProvisioningWizard < BaseWizard
     @timezone = ask('Enter an IANA timezone identifier (e.g. America/New_York, Pacific/Auckland, UTC)')
   end
 
+  def get_ntp_host
+    @ntp_host = ask('Enter a list of NTP hosts, separated by commas. First in the list will be the default.')
+  end
+
   def domain
     @domain ||= Facter.value :domain
   end

--- a/modules/foreman/manifests/plugin/staypuft.pp
+++ b/modules/foreman/manifests/plugin/staypuft.pp
@@ -79,8 +79,9 @@ class foreman::plugin::staypuft(
     require => Exec['NTP sync'],
   }
 
+  $ntpdate_host = split($ntp_host, ',')
   exec { 'NTP sync':
-    command => "/sbin/service ntpd stop; /usr/sbin/ntpdate $ntp_host",
+    command => "/sbin/service ntpd stop; /usr/sbin/ntpdate ${ntpdate_host[0]}",
     notify  => Service['ntpd'],
     require => [Package['ntp'], Package['ntpdate']],
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1191732

Add the option to specify multiple ntp servers, and write this list to
the OS parameters.