### PR TITLE
Revert "BZ #1180322: Install mariadb on controllers before puppet"

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -427,11 +427,6 @@ yum -t -y -e 0 update
 # ensure firewalld is absent (BZ#1125075)
 yum -t -y -e 0 remove firewalld
 
-# Ensure mariadb is installed on controllers before puppet run
-<% if @host.hostgroup.to_s.include?("Controller") -%>
-yum -t -y -e 0 install mariadb
-<% end -%>
-
 <% if puppet_enabled %>
 # and add the puppet package
 yum -t -y -e 0 install puppet
@@ -614,11 +609,6 @@ yum -t -y -e 0 update
 
 # ensure firewalld is absent (BZ#1125075)
 yum -t -y -e 0 remove firewalld
-
-# Ensure mariadb is installed on controllers before puppet run
-<% if @host.hostgroup.to_s.include?("Controller") -%>
-yum -t -y -e 0 install mariadb
-<% end -%>
 
 <% if puppet_enabled %>
 echo "Configuring puppet"


### PR DESCRIPTION
This reverts commit 2a5186777d01135c529c6ff11d4333d4c6cfc71f.

This patch was an attempt to avoid an error which has been solved
elsewhere.