### PR TITLE
BZ#1197780 Remove HWADDR from bonded interface definition

### DIFF
--- a/modules/network/templates/ifcfg-bond.erb
+++ b/modules/network/templates/ifcfg-bond.erb
@@ -2,7 +2,6 @@
 ### File managed by Puppet
 ###
 DEVICE=<%= @interface %>
-HWADDR=<%= @macaddress %>
 MASTER=<%= @master %>
 SLAVE=yes
 TYPE=Ethernet


### PR DESCRIPTION
foreman-installer inserts the HWADDR line when writes the configuration file for a bonded interface that is used for provisioning, causing it to lose the IP address and fails.
