### PR TITLE
rhbz#1196310 - include rhel-ha repo by default

### DIFF
--- a/hooks/lib/subscription_seeder.rb
+++ b/hooks/lib/subscription_seeder.rb
@@ -23,7 +23,7 @@ class SubscriptionSeeder < BaseSeeder
 
     @sm_username = @config.get_custom(:sm_username) || ''
     @sm_password = @config.get_custom(:sm_password) || ''
-    @repositories = @config.get_custom(:repositories) || 'rhel-7-server-openstack-6.0-rpms rhel-7-server-openstack-6.0-installer-rpms rhel-7-server-rh-common-rpms'
+    @repositories = @config.get_custom(:repositories) || 'rhel-7-server-openstack-6.0-rpms rhel-7-server-openstack-6.0-installer-rpms rhel-7-server-rh-common-rpms rhel-ha-for-rhel-7-server-rpms'
     @sm_proxy_user = @config.get_custom(:sm_proxy_user) || ''
     @sm_proxy_password = @config.get_custom(:sm_proxy_password) || ''
     @sm_proxy_host = @config.get_custom(:sm_proxy_host) || ''


### PR DESCRIPTION
As of RHEL-OSP6, HA channel provides the necessary pacemaker bits. This will ensure sane default repositories, can be overridden in Hosts-Operating Systems-Parameters.