### PR TITLE
BZ#1199827 Disable all repos before enabling

### DIFF
--- a/hooks/lib/provisioning_seeder.rb
+++ b/hooks/lib/provisioning_seeder.rb
@@ -1058,12 +1058,14 @@ name: redhat_register
     <% end %>
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
+    subscription-manager repos --disable=*
     <%= "subscription-manager repos #{@host.params['subscription_manager_repos'].split(/[\s,]/).reject { |r| r.empty? }.map { |r| '--enable=' + r }.join(' ')}" if @host.params['subscription_manager_repos'] %>
   <% elsif @host.params['activation_key'] %>
     rpm -Uvh <%= @host.params['subscription_manager_host'] %>/pub/candlepin-cert-consumer-latest.noarch.rpm
     subscription-manager register --org="<%= @host.params['subscription_manager_org'] %>" --activationkey="<%= @host.params['activation_key'] %>"
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
+    subscription-manager repos --disable=*
     <%= "subscription-manager repos #{@host.params['subscription_manager_repos'].split(',').map { |r| '--enable=' + r.strip }.join(' ')}" if @host.params['subscription_manager_repos'] %>
   <% else %>
     # Not registering host.params['activation_key'] not found.


### PR DESCRIPTION
Installer should disable all repos before enabling just the right ones to avoid conflicts later on. For this to work, a related change to subscription_seeder.rb is needed.